### PR TITLE
fixed link to CONTRIBUTING.MD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ We’ve put together some commonly asked questions and answers about the Camunda
 
 1. To join the community, [open an issue](https://github.com/camunda-community-hub/community/issues) in this repository and ask to be invited to join the Camunda Community Hub if you are not already a member.
 
-2. Sign our [CLA](https://cla-assistant.io/camunda-community-hub/community) and agree to our [Code of Conduct](https://camunda.com/events/code-conduct/). Then, review our [Contributor Guide](/docs/CONTRIBUTING.MD).
+2. Sign our [CLA](https://cla-assistant.io/camunda-community-hub/community) and agree to our [Code of Conduct](https://camunda.com/events/code-conduct/). Then, review our [Contributor Guide](/CONTRIBUTING.MD).
 
 3. Now either:
     * **Start a new community extension** by [opening an issue](https://github.com/Camunda-Community-Hub/community/issues/new/choose) using the `New Community Extension Proposal` template. Follow our complete documentation on [creating a new extension here.](maintainers-reviewers/creating-new-extensions.md)
     * **Transfer your existing repository** into the Camunda Community Hub (do not fork it into the Hub) following [these instructions.](maintainers-reviewers/transferring-extensions.md)
-    * **Browse our existing projects** and [contribute](/docs/CONTRIBUTING.MD) -- code and non-code contributions welcome!
+    * **Browse our existing projects** and [contribute](/CONTRIBUTING.MD) -- code and non-code contributions welcome!
 
 ### Contributor resources & documentation
-* [Contributor guide](/docs/CONTRIBUTING.MD)
+* [Contributor guide](/CONTRIBUTING.MD)
 * [Issue triage and labeling](/issue-triage.md)
 * [Maintainers, start here](maintainers-reviewers/maintainers-start-here.md)
 * [Maintainer & reviewer expectations](maintainers-reviewers/maintainer-reviewer-expectations.md)


### PR DESCRIPTION
I'm just a passer by looking at your very cool github organization README.me file for inspiration and happened on some broken links to your `CONTRIBUTING.MD` file here. 

The original links were looking for it in `/docs/CONTRIBUTING.MD`. 

I've fixed the links and tested in my own forked repo to ensure they work. 

An alternative might be that someone could move `CONTRIBUTING.MD` to the `docs/` folder. But this is the easier fix. And as I'm not really a member of the community, if this did the trick for you, I thought I would just pass it along. Feel free to reject and address otherwise if that works better for you. 

Cheers! 🙂 